### PR TITLE
Use environments with travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,11 @@ install:
   - pip install tox
 
 script:
-  - tox -e py27
-  - tox -e lint
+  - tox
+
+env:
+  - TOXENV=py27
+  - TOXENV=lint
 
 after_success:
   - tox -e coveralls


### PR DESCRIPTION
This will allow lint and py27 to show up as two separate build steps.