### PR TITLE
Remove lint instructions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,12 +51,6 @@ Tests can be run using tox.
 
     tox -e py27
 
-Lint can also be run using tox. This will fire off two pylint commands, one
-for the main ndb library and one for the tests which have slightly relaxed
-requirements.
-
-    tox -e lint
-
 to run coverage tests, run
 
     tox -e cover


### PR DESCRIPTION
We removed the linter because it was generating too much noise, removing instructions from the contributing doc as well.