### PR TITLE
Use compact encoding for JsonProperty. This fixes #231.

### DIFF
--- a/ndb/model.py
+++ b/ndb/model.py
@@ -1886,7 +1886,7 @@ class JsonProperty(BlobProperty):
       import json
     except ImportError:
       import simplejson as json
-    return json.dumps(value)
+    return json.dumps(value, separators=(',', ':'))
 
   def _from_base_type(self, value):
     try:


### PR DESCRIPTION
An easy way to make the JSON format more compact. It's still valid JSON, so this is should be completely safe to do.