### PR TITLE
Refactor: freeze requirements, extract functionality from context.py

### DIFF
--- a/ndb/autobatcher.py
+++ b/ndb/autobatcher.py
@@ -1,0 +1,155 @@
+#
+# Copyright 2008 The ndb Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from . import eventloop
+from . import utils
+from . import tasklets
+
+__all__ = ['AutoBatcher']
+
+class AutoBatcher(object):
+  """Batches multiple async calls if they share the same rpc options.
+
+  Here is an example to explain what this class does.
+
+  Life of a key.get_async(options) API call:
+  *) Key gets the singleton Context instance and invokes Context.get.
+  *) Context.get calls Context._get_batcher.add(key, options). This
+     returns a future "fut" as the return value of key.get_async.
+     At this moment, key.get_async returns.
+
+  *) When more than "limit" number of _get_batcher.add() was called,
+     _get_batcher invokes its self._todo_tasklet, Context._get_tasklet,
+     with the list of keys seen so far.
+  *) Context._get_tasklet fires a MultiRPC and waits on it.
+  *) Upon MultiRPC completion, Context._get_tasklet passes on the results
+     to the respective "fut" from key.get_async.
+
+  *) If user calls "fut".get_result() before "limit" number of add() was called,
+     "fut".get_result() will repeatedly call eventloop.run1().
+  *) After processing immediate callbacks, eventloop will run idlers.
+     AutoBatcher._on_idle is an idler.
+  *) _on_idle will run the "todo_tasklet" before the batch is full.
+
+  So the engine is todo_tasklet, which is a proxy tasklet that can combine
+  arguments into batches and passes along results back to respective futures.
+  This class is mainly a helper that invokes todo_tasklet with the right
+  arguments at the right time.
+  """
+
+  def __init__(self, todo_tasklet, limit):
+    """Init.
+
+    Args:
+      todo_tasklet: the tasklet that actually fires RPC and waits on a MultiRPC.
+        It should take a list of (future, arg) pairs and an "options" as
+        arguments. "options" are rpc options.
+      limit: max number of items to batch for each distinct value of "options".
+    """
+    self._todo_tasklet = todo_tasklet
+    self._limit = limit
+    # A map from "options" to a list of (future, arg) tuple.
+    # future is the future return from a single async operations.
+    self._queues = {}
+    self._running = []  # A list of in-flight todo_tasklet futures.
+    self._cache = {}  # Cache of in-flight todo_tasklet futures.
+
+  def __repr__(self):
+    return '%s(%s)' % (self.__class__.__name__, self._todo_tasklet.__name__)
+
+  def run_queue(self, options, todo):
+    """Actually run the _todo_tasklet."""
+    utils.logging_debug('AutoBatcher(%s): %d items',
+                        self._todo_tasklet.__name__, len(todo))
+    batch_fut = self._todo_tasklet(todo, options)
+    self._running.append(batch_fut)
+    # Add a callback when we're done.
+    batch_fut.add_callback(self._finished_callback, batch_fut, todo)
+
+  def _on_idle(self):
+    """An idler eventloop can run.
+
+    Eventloop calls this when it has finished processing all immediate
+    callbacks. This method runs _todo_tasklet even before the batch is full.
+    """
+    if not self.action():
+      return None
+    return True
+
+  def add(self, arg, options=None):
+    """Adds an arg and gets back a future.
+
+    Args:
+      arg: one argument for _todo_tasklet.
+      options: rpc options.
+
+    Return:
+      An instance of future, representing the result of running
+        _todo_tasklet without batching.
+    """
+    fut = tasklets.Future('%s.add(%s, %s)' % (self, arg, options))
+    todo = self._queues.get(options)
+    if todo is None:
+      utils.logging_debug('AutoBatcher(%s): creating new queue for %r',
+                          self._todo_tasklet.__name__, options)
+      if not self._queues:
+        eventloop.add_idle(self._on_idle)
+      todo = self._queues[options] = []
+    todo.append((fut, arg))
+    if len(todo) >= self._limit:
+      del self._queues[options]
+      self.run_queue(options, todo)
+    return fut
+
+  def add_once(self, arg, options=None):
+    cache_key = (arg, options)
+    fut = self._cache.get(cache_key)
+    if fut is None:
+      fut = self.add(arg, options)
+      self._cache[cache_key] = fut
+      fut.add_immediate_callback(self._cache.__delitem__, cache_key)
+    return fut
+
+  def action(self):
+    queues = self._queues
+    if not queues:
+      return False
+    options, todo = queues.popitem()  # TODO: Should this use FIFO ordering?
+    self.run_queue(options, todo)
+    return True
+
+  def _finished_callback(self, batch_fut, todo):
+    """Passes exception along.
+
+    Args:
+      batch_fut: the batch future returned by running todo_tasklet.
+      todo: (fut, option) pair. fut is the future return by each add() call.
+
+    If the batch fut was successful, it has already called fut.set_result()
+    on other individual futs. This method only handles when the batch fut
+    encountered an exception.
+    """
+    self._running.remove(batch_fut)
+    err = batch_fut.get_exception()
+    if err is not None:
+      tb = batch_fut.get_traceback()
+      for (fut, _) in todo:
+        if not fut.done():
+          fut.set_exception(err, tb)
+
+  @tasklets.tasklet
+  def flush(self):
+    while self._running or self.action():
+      if self._running:
+        yield self._running  # A list of Futures

--- a/ndb/autobatcher.py
+++ b/ndb/autobatcher.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2008 The ndb Authors. All Rights Reserved.
+# Copyright 2017 The ndb Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ndb/context.py
+++ b/ndb/context.py
@@ -127,6 +127,9 @@ def _make_ctx_options(ctx_options, config_cls=ContextOptions):
 
 
 class Context(object):
+  # NOTE: The default memcache prefix is altered if an incompatible change is
+  # required. Remember to check release notes when using a custom prefix.
+  _memcache_prefix = 'NDB9:'  # TODO: Might make this configurable
 
   def __init__(self, conn=None, auto_batcher_class=autobatcher.AutoBatcher, config=None,
                parent_context=None):
@@ -168,8 +171,6 @@ class Context(object):
                      ]
     self._cache = {}
     self._on_commit_queue = []
-
-  _memcache_prefix = memcache_client.MemcacheClient._memcache_prefix
 
   @tasklets.tasklet
   def flush(self):

--- a/ndb/context.py
+++ b/ndb/context.py
@@ -18,25 +18,23 @@
 import logging
 import sys
 
+from .google_imports import ProtocolBuffer
 from .google_imports import datastore  # For taskqueue coordination
 from .google_imports import datastore_errors
+from .google_imports import datastore_rpc
+from .google_imports import entity_pb
 from .google_imports import memcache
 from .google_imports import namespace_manager
 from .google_imports import urlfetch
-from .google_imports import datastore_rpc
-from .google_imports import entity_pb
 
-from .google_imports import ProtocolBuffer
-
+from . import autobatcher
 from . import key as key_module
 from . import model
 from . import tasklets
-from . import eventloop
 from . import utils
 
-__all__ = ['Context', 'ContextOptions', 'TransactionOptions', 'AutoBatcher',
-           'EVENTUAL_CONSISTENCY',
-          ]
+__all__ = ['Context', 'ContextOptions', 'TransactionOptions', 'EVENTUAL_CONSISTENCY',
+           ]
 
 _LOCK_TIME = 32  # Time to lock out memcache.add() after datastore updates.
 _LOCKED = 0  # Special value to store in memcache indicating locked value.
@@ -128,146 +126,9 @@ def _make_ctx_options(ctx_options, config_cls=ContextOptions):
   return config_cls(**ctx_options)
 
 
-class AutoBatcher(object):
-  """Batches multiple async calls if they share the same rpc options.
-
-  Here is an example to explain what this class does.
-
-  Life of a key.get_async(options) API call:
-  *) Key gets the singleton Context instance and invokes Context.get.
-  *) Context.get calls Context._get_batcher.add(key, options). This
-     returns a future "fut" as the return value of key.get_async.
-     At this moment, key.get_async returns.
-
-  *) When more than "limit" number of _get_batcher.add() was called,
-     _get_batcher invokes its self._todo_tasklet, Context._get_tasklet,
-     with the list of keys seen so far.
-  *) Context._get_tasklet fires a MultiRPC and waits on it.
-  *) Upon MultiRPC completion, Context._get_tasklet passes on the results
-     to the respective "fut" from key.get_async.
-
-  *) If user calls "fut".get_result() before "limit" number of add() was called,
-     "fut".get_result() will repeatedly call eventloop.run1().
-  *) After processing immediate callbacks, eventloop will run idlers.
-     AutoBatcher._on_idle is an idler.
-  *) _on_idle will run the "todo_tasklet" before the batch is full.
-
-  So the engine is todo_tasklet, which is a proxy tasklet that can combine
-  arguments into batches and passes along results back to respective futures.
-  This class is mainly a helper that invokes todo_tasklet with the right
-  arguments at the right time.
-  """
-
-  def __init__(self, todo_tasklet, limit):
-    """Init.
-
-    Args:
-      todo_tasklet: the tasklet that actually fires RPC and waits on a MultiRPC.
-        It should take a list of (future, arg) pairs and an "options" as
-        arguments. "options" are rpc options.
-      limit: max number of items to batch for each distinct value of "options".
-    """
-    self._todo_tasklet = todo_tasklet
-    self._limit = limit
-    # A map from "options" to a list of (future, arg) tuple.
-    # future is the future return from a single async operations.
-    self._queues = {}
-    self._running = []  # A list of in-flight todo_tasklet futures.
-    self._cache = {}  # Cache of in-flight todo_tasklet futures.
-
-  def __repr__(self):
-    return '%s(%s)' % (self.__class__.__name__, self._todo_tasklet.__name__)
-
-  def run_queue(self, options, todo):
-    """Actually run the _todo_tasklet."""
-    utils.logging_debug('AutoBatcher(%s): %d items',
-                        self._todo_tasklet.__name__, len(todo))
-    batch_fut = self._todo_tasklet(todo, options)
-    self._running.append(batch_fut)
-    # Add a callback when we're done.
-    batch_fut.add_callback(self._finished_callback, batch_fut, todo)
-
-  def _on_idle(self):
-    """An idler eventloop can run.
-
-    Eventloop calls this when it has finished processing all immediate
-    callbacks. This method runs _todo_tasklet even before the batch is full.
-    """
-    if not self.action():
-      return None
-    return True
-
-  def add(self, arg, options=None):
-    """Adds an arg and gets back a future.
-
-    Args:
-      arg: one argument for _todo_tasklet.
-      options: rpc options.
-
-    Return:
-      An instance of future, representing the result of running
-        _todo_tasklet without batching.
-    """
-    fut = tasklets.Future('%s.add(%s, %s)' % (self, arg, options))
-    todo = self._queues.get(options)
-    if todo is None:
-      utils.logging_debug('AutoBatcher(%s): creating new queue for %r',
-                          self._todo_tasklet.__name__, options)
-      if not self._queues:
-        eventloop.add_idle(self._on_idle)
-      todo = self._queues[options] = []
-    todo.append((fut, arg))
-    if len(todo) >= self._limit:
-      del self._queues[options]
-      self.run_queue(options, todo)
-    return fut
-
-  def add_once(self, arg, options=None):
-    cache_key = (arg, options)
-    fut = self._cache.get(cache_key)
-    if fut is None:
-      fut = self.add(arg, options)
-      self._cache[cache_key] = fut
-      fut.add_immediate_callback(self._cache.__delitem__, cache_key)
-    return fut
-
-  def action(self):
-    queues = self._queues
-    if not queues:
-      return False
-    options, todo = queues.popitem()  # TODO: Should this use FIFO ordering?
-    self.run_queue(options, todo)
-    return True
-
-  def _finished_callback(self, batch_fut, todo):
-    """Passes exception along.
-
-    Args:
-      batch_fut: the batch future returned by running todo_tasklet.
-      todo: (fut, option) pair. fut is the future return by each add() call.
-
-    If the batch fut was successful, it has already called fut.set_result()
-    on other individual futs. This method only handles when the batch fut
-    encountered an exception.
-    """
-    self._running.remove(batch_fut)
-    err = batch_fut.get_exception()
-    if err is not None:
-      tb = batch_fut.get_traceback()
-      for (fut, _) in todo:
-        if not fut.done():
-          fut.set_exception(err, tb)
-
-  @tasklets.tasklet
-  def flush(self):
-    while self._running or self.action():
-      if self._running:
-        yield self._running  # A list of Futures
-
-
 class Context(object):
 
-  def __init__(self, conn=None, auto_batcher_class=AutoBatcher, config=None,
+  def __init__(self, conn=None, auto_batcher_class=autobatcher.AutoBatcher, config=None,
                parent_context=None):
     # NOTE: If conn is not None, config is only used to get the
     # auto-batcher limits.

--- a/ndb/context.py
+++ b/ndb/context.py
@@ -24,11 +24,11 @@ from .google_imports import datastore_errors
 from .google_imports import datastore_rpc
 from .google_imports import entity_pb
 from .google_imports import memcache
-from .google_imports import namespace_manager
 from .google_imports import urlfetch
 
 from . import autobatcher
 from . import key as key_module
+from . import memcache_client
 from . import model
 from . import tasklets
 from . import utils
@@ -156,30 +156,20 @@ class Context(object):
     max_memcache = (ContextOptions.max_memcache_items(config, conn.config) or
                     datastore_rpc.Connection.MAX_GET_KEYS)
     # Create the memcache auto-batchers.
-    self._memcache_get_batcher = auto_batcher_class(self._memcache_get_tasklet,
-                                                    max_memcache)
-    self._memcache_set_batcher = auto_batcher_class(self._memcache_set_tasklet,
-                                                    max_memcache)
-    self._memcache_del_batcher = auto_batcher_class(self._memcache_del_tasklet,
-                                                    max_memcache)
-    self._memcache_off_batcher = auto_batcher_class(self._memcache_off_tasklet,
-                                                    max_memcache)
+    self.memcache_client = memcache_client.MemcacheClient(self._conn, auto_batcher_class, max_memcache)
     # Create a list of batchers for flush().
     self._batchers = [self._get_batcher,
                       self._put_batcher,
                       self._delete_batcher,
-                      self._memcache_get_batcher,
-                      self._memcache_set_batcher,
-                      self._memcache_del_batcher,
-                      self._memcache_off_batcher,
+                      self.memcache_client.memcache_get_batcher,
+                      self.memcache_client.memcache_set_batcher,
+                      self.memcache_client.memcache_del_batcher,
+                      self.memcache_client.memcache_off_batcher,
                      ]
     self._cache = {}
-    self._memcache = memcache.Client()
     self._on_commit_queue = []
 
-  # NOTE: The default memcache prefix is altered if an incompatible change is
-  # required. Remember to check release notes when using a custom prefix.
-  _memcache_prefix = 'NDB9:'  # TODO: Might make this configurable.
+  _memcache_prefix = memcache_client.MemcacheClient._memcache_prefix
 
   @tasklets.tasklet
   def flush(self):
@@ -954,100 +944,9 @@ class Context(object):
       futures.append(fut)
     yield futures
 
-  @tasklets.tasklet
-  def _memcache_get_tasklet(self, todo, options):
-    if not todo:
-      raise RuntimeError('Nothing to do.')
-    for_cas, namespace, deadline = options
-    keys = set()
-    for unused_fut, key in todo:
-      keys.add(key)
-    rpc = memcache.create_rpc(deadline=deadline)
-    results = yield self._memcache.get_multi_async(keys, for_cas=for_cas,
-                                                   namespace=namespace,
-                                                   rpc=rpc)
-    for fut, key in todo:
-      fut.set_result(results.get(key))
-
-  @tasklets.tasklet
-  def _memcache_set_tasklet(self, todo, options):
-    if not todo:
-      raise RuntimeError('Nothing to do.')
-    opname, time, namespace, deadline = options
-    methodname = opname + '_multi_async'
-    method = getattr(self._memcache, methodname)
-    mapping = {}
-    for unused_fut, (key, value) in todo:
-      mapping[key] = value
-    rpc = memcache.create_rpc(deadline=deadline)
-    results = yield method(mapping, time=time, namespace=namespace, rpc=rpc)
-    for fut, (key, unused_value) in todo:
-      if results is None:
-        status = memcache.MemcacheSetResponse.ERROR
-      else:
-        status = results.get(key)
-      fut.set_result(status == memcache.MemcacheSetResponse.STORED)
-
-  @tasklets.tasklet
-  def _memcache_del_tasklet(self, todo, options):
-    if not todo:
-      raise RuntimeError('Nothing to do.')
-    seconds, namespace, deadline = options
-    keys = set()
-    for unused_fut, key in todo:
-      keys.add(key)
-    rpc = memcache.create_rpc(deadline=deadline)
-    statuses = yield self._memcache.delete_multi_async(keys, seconds=seconds,
-                                                       namespace=namespace,
-                                                       rpc=rpc)
-    status_key_mapping = {}
-    if statuses:  # On network error, statuses is None.
-      for key, status in zip(keys, statuses):
-        status_key_mapping[key] = status
-    for fut, key in todo:
-      status = status_key_mapping.get(key, memcache.DELETE_NETWORK_FAILURE)
-      fut.set_result(status)
-
-  @tasklets.tasklet
-  def _memcache_off_tasklet(self, todo, options):
-    if not todo:
-      raise RuntimeError('Nothing to do.')
-    initial_value, namespace, deadline = options
-    mapping = {}  # {key: delta}
-    for unused_fut, (key, delta) in todo:
-      mapping[key] = delta
-    rpc = memcache.create_rpc(deadline=deadline)
-    results = yield self._memcache.offset_multi_async(
-        mapping, initial_value=initial_value, namespace=namespace, rpc=rpc)
-    for fut, (key, unused_delta) in todo:
-      fut.set_result(results.get(key))
-
   def memcache_get(self, key, for_cas=False, namespace=None, use_cache=False,
                    deadline=None):
-    """An auto-batching wrapper for memcache.get() or .get_multi().
-
-    Args:
-      key: Key to set.  This must be a string; no prefix is applied.
-      for_cas: If True, request and store CAS ids on the Context.
-      namespace: Optional namespace.
-      deadline: Optional deadline for the RPC.
-
-    Returns:
-      A Future (!) whose return value is the value retrieved from
-      memcache, or None.
-    """
-    if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
-    if not isinstance(for_cas, bool):
-      raise TypeError('for_cas must be a bool; received %r' % for_cas)
-    if namespace is None:
-      namespace = namespace_manager.get_namespace()
-    options = (for_cas, namespace, deadline)
-    batcher = self._memcache_get_batcher
-    if use_cache:
-      return batcher.add_once(key, options)
-    else:
-      return batcher.add(key, options)
+    return self.memcache_client.memcache_get(key, for_cas, namespace, use_cache, deadline)
 
   # XXX: Docstrings below.
 
@@ -1057,85 +956,27 @@ class Context(object):
 
   def memcache_set(self, key, value, time=0, namespace=None, use_cache=False,
                    deadline=None):
-    if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
-    if not isinstance(time, (int, long)):
-      raise TypeError('time must be a number; received %r' % time)
-    if namespace is None:
-      namespace = namespace_manager.get_namespace()
-    options = ('set', time, namespace, deadline)
-    batcher = self._memcache_set_batcher
-    if use_cache:
-      return batcher.add_once((key, value), options)
-    else:
-      return batcher.add((key, value), options)
+    return self.memcache_client.memcache_set(key, value, time, namespace, use_cache, deadline)
 
   def memcache_add(self, key, value, time=0, namespace=None, deadline=None):
-    if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
-    if not isinstance(time, (int, long)):
-      raise TypeError('time must be a number; received %r' % time)
-    if namespace is None:
-      namespace = namespace_manager.get_namespace()
-    return self._memcache_set_batcher.add((key, value),
-                                          ('add', time, namespace, deadline))
+    return self.memcache_client.memcache_add(key, value, time, namespace, deadline)
 
   def memcache_replace(self, key, value, time=0, namespace=None, deadline=None):
-    if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
-    if not isinstance(time, (int, long)):
-      raise TypeError('time must be a number; received %r' % time)
-    if namespace is None:
-      namespace = namespace_manager.get_namespace()
-    options = ('replace', time, namespace, deadline)
-    return self._memcache_set_batcher.add((key, value), options)
+    return self.memcache_client.memcache_replace(key, value, time, namespace, deadline)
 
   def memcache_cas(self, key, value, time=0, namespace=None, deadline=None):
-    if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
-    if not isinstance(time, (int, long)):
-      raise TypeError('time must be a number; received %r' % time)
-    if namespace is None:
-      namespace = namespace_manager.get_namespace()
-    return self._memcache_set_batcher.add((key, value),
-                                          ('cas', time, namespace, deadline))
+    return self.memcache_client.memcache_cas(key, value, time, namespace, deadline)
 
   def memcache_delete(self, key, seconds=0, namespace=None, deadline=None):
-    if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
-    if not isinstance(seconds, (int, long)):
-      raise TypeError('seconds must be a number; received %r' % seconds)
-    if namespace is None:
-      namespace = namespace_manager.get_namespace()
-    return self._memcache_del_batcher.add(key, (seconds, namespace, deadline))
+    return self.memcache_client.memcache_delete(key, seconds, namespace, deadline)
 
   def memcache_incr(self, key, delta=1, initial_value=None, namespace=None,
                     deadline=None):
-    if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
-    if not isinstance(delta, (int, long)):
-      raise TypeError('delta must be a number; received %r' % delta)
-    if initial_value is not None and not isinstance(initial_value, (int, long)):
-      raise TypeError('initial_value must be a number or None; received %r' %
-                      initial_value)
-    if namespace is None:
-      namespace = namespace_manager.get_namespace()
-    return self._memcache_off_batcher.add((key, delta),
-                                          (initial_value, namespace, deadline))
+    return self.memcache_client.memcache_incr(key, delta, initial_value, namespace, deadline)
 
   def memcache_decr(self, key, delta=1, initial_value=None, namespace=None,
                     deadline=None):
-    if not isinstance(key, basestring):
-      raise TypeError('key must be a string; received %r' % key)
-    if not isinstance(delta, (int, long)):
-      raise TypeError('delta must be a number; received %r' % delta)
-    if initial_value is not None and not isinstance(initial_value, (int, long)):
-      raise TypeError('initial_value must be a number or None; received %r' %
-                      initial_value)
-    if namespace is None:
-      namespace = namespace_manager.get_namespace()
-    return self._memcache_off_batcher.add((key, -delta),
-                                          (initial_value, namespace, deadline))
+    return self.memcache_client.memcache_decr(key, delta, initial_value, namespace, deadline)
 
   @tasklets.tasklet
   def urlfetch(self, url, payload=None, method='GET', headers={},

--- a/ndb/context_test.py
+++ b/ndb/context_test.py
@@ -31,6 +31,7 @@ from .google_imports import taskqueue
 from .google_test_imports import unittest
 from .google_test_imports import real_unittest
 
+from . import autobatcher
 from . import context
 from . import eventloop
 from . import model
@@ -44,7 +45,7 @@ STORED = True
 NOT_STORED = False
 
 
-class MyAutoBatcher(context.AutoBatcher):
+class MyAutoBatcher(autobatcher.AutoBatcher):
 
   _log = []
 

--- a/ndb/memcache_client.py
+++ b/ndb/memcache_client.py
@@ -1,0 +1,220 @@
+#
+# Copyright 2017 The ndb Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from .google_imports import namespace_manager
+from .google_imports import memcache
+
+from . import autobatcher
+from . import tasklets
+
+class MemcacheClient(object):
+  # NOTE: The default memcache prefix is altered if an incompatible change is
+  # required. Remember to check release notes when using a custom prefix.
+  _memcache_prefix = 'NDB9:'  # TODO: Might make this configurable
+
+  def __init__(self, conn=None, auto_batcher_class=autobatcher.AutoBatcher, max_memcache=None):
+    # NOTE: If conn is not None, config is only used to get the
+    # auto-batcher limits.
+    self._conn = conn
+    self._auto_batcher_class = auto_batcher_class
+
+    # Create the memcache auto-batchers.
+    self.memcache_get_batcher = auto_batcher_class(self._memcache_get_tasklet, max_memcache)
+    self.memcache_set_batcher = auto_batcher_class(self._memcache_set_tasklet, max_memcache)
+    self.memcache_del_batcher = auto_batcher_class(self._memcache_del_tasklet, max_memcache)
+    self.memcache_off_batcher = auto_batcher_class(self._memcache_off_tasklet, max_memcache)
+    self._memcache = memcache.Client()
+
+  @tasklets.tasklet
+  def _memcache_get_tasklet(self, todo, options):
+    if not todo:
+      raise RuntimeError('Nothing to do.')
+    for_cas, namespace, deadline = options
+    keys = set()
+    for unused_fut, key in todo:
+      keys.add(key)
+    rpc = memcache.create_rpc(deadline=deadline)
+    results = yield self._memcache.get_multi_async(keys, for_cas=for_cas,
+                                                   namespace=namespace,
+                                                   rpc=rpc)
+    for fut, key in todo:
+      fut.set_result(results.get(key))
+
+  @tasklets.tasklet
+  def _memcache_set_tasklet(self, todo, options):
+    if not todo:
+      raise RuntimeError('Nothing to do.')
+    opname, time, namespace, deadline = options
+    methodname = opname + '_multi_async'
+    method = getattr(self._memcache, methodname)
+    mapping = {}
+    for unused_fut, (key, value) in todo:
+      mapping[key] = value
+    rpc = memcache.create_rpc(deadline=deadline)
+    results = yield method(mapping, time=time, namespace=namespace, rpc=rpc)
+    for fut, (key, unused_value) in todo:
+      if results is None:
+        status = memcache.MemcacheSetResponse.ERROR
+      else:
+        status = results.get(key)
+      fut.set_result(status == memcache.MemcacheSetResponse.STORED)
+
+  @tasklets.tasklet
+  def _memcache_del_tasklet(self, todo, options):
+    if not todo:
+      raise RuntimeError('Nothing to do.')
+    seconds, namespace, deadline = options
+    keys = set()
+    for unused_fut, key in todo:
+      keys.add(key)
+    rpc = memcache.create_rpc(deadline=deadline)
+    statuses = yield self._memcache.delete_multi_async(keys, seconds=seconds,
+                                                       namespace=namespace,
+                                                       rpc=rpc)
+    status_key_mapping = {}
+    if statuses:  # On network error, statuses is None.
+      for key, status in zip(keys, statuses):
+        status_key_mapping[key] = status
+    for fut, key in todo:
+      status = status_key_mapping.get(key, memcache.DELETE_NETWORK_FAILURE)
+      fut.set_result(status)
+
+  @tasklets.tasklet
+  def _memcache_off_tasklet(self, todo, options):
+    if not todo:
+      raise RuntimeError('Nothing to do.')
+    initial_value, namespace, deadline = options
+    mapping = {}  # {key: delta}
+    for unused_fut, (key, delta) in todo:
+      mapping[key] = delta
+    rpc = memcache.create_rpc(deadline=deadline)
+    results = yield self._memcache.offset_multi_async(
+        mapping, initial_value=initial_value, namespace=namespace, rpc=rpc)
+    for fut, (key, unused_delta) in todo:
+      fut.set_result(results.get(key))
+
+  def memcache_get(self, key, for_cas=False, namespace=None, use_cache=False,
+                   deadline=None):
+    """An auto-batching wrapper for memcache.get() or .get_multi().
+
+    Args:
+      key: Key to set.  This must be a string; no prefix is applied.
+      for_cas: If True, request and store CAS ids on the Context.
+      namespace: Optional namespace.
+      deadline: Optional deadline for the RPC.
+
+    Returns:
+      A Future (!) whose return value is the value retrieved from
+      memcache, or None.
+    """
+    if not isinstance(key, basestring):
+      raise TypeError('key must be a string; received %r' % key)
+    if not isinstance(for_cas, bool):
+      raise TypeError('for_cas must be a bool; received %r' % for_cas)
+    if namespace is None:
+      namespace = namespace_manager.get_namespace()
+    options = (for_cas, namespace, deadline)
+    batcher = self.memcache_get_batcher
+    if use_cache:
+      return batcher.add_once(key, options)
+    else:
+      return batcher.add(key, options)
+
+  # XXX: Docstrings below.
+
+  def memcache_gets(self, key, namespace=None, use_cache=False, deadline=None):
+    return self.memcache_get(key, for_cas=True, namespace=namespace,
+                             use_cache=use_cache, deadline=deadline)
+
+  def memcache_set(self, key, value, time=0, namespace=None, use_cache=False,
+                   deadline=None):
+    if not isinstance(key, basestring):
+      raise TypeError('key must be a string; received %r' % key)
+    if not isinstance(time, (int, long)):
+      raise TypeError('time must be a number; received %r' % time)
+    if namespace is None:
+      namespace = namespace_manager.get_namespace()
+    options = ('set', time, namespace, deadline)
+    batcher = self.memcache_set_batcher
+    if use_cache:
+      return batcher.add_once((key, value), options)
+    else:
+      return batcher.add((key, value), options)
+
+  def memcache_add(self, key, value, time=0, namespace=None, deadline=None):
+    if not isinstance(key, basestring):
+      raise TypeError('key must be a string; received %r' % key)
+    if not isinstance(time, (int, long)):
+      raise TypeError('time must be a number; received %r' % time)
+    if namespace is None:
+      namespace = namespace_manager.get_namespace()
+    return self.memcache_set_batcher.add((key, value),
+                                          ('add', time, namespace, deadline))
+
+  def memcache_replace(self, key, value, time=0, namespace=None, deadline=None):
+    if not isinstance(key, basestring):
+      raise TypeError('key must be a string; received %r' % key)
+    if not isinstance(time, (int, long)):
+      raise TypeError('time must be a number; received %r' % time)
+    if namespace is None:
+      namespace = namespace_manager.get_namespace()
+    options = ('replace', time, namespace, deadline)
+    return self.memcache_set_batcher.add((key, value), options)
+
+  def memcache_cas(self, key, value, time=0, namespace=None, deadline=None):
+    if not isinstance(key, basestring):
+      raise TypeError('key must be a string; received %r' % key)
+    if not isinstance(time, (int, long)):
+      raise TypeError('time must be a number; received %r' % time)
+    if namespace is None:
+      namespace = namespace_manager.get_namespace()
+    return self.memcache_set_batcher.add((key, value),
+                                          ('cas', time, namespace, deadline))
+
+  def memcache_delete(self, key, seconds=0, namespace=None, deadline=None):
+    if not isinstance(key, basestring):
+      raise TypeError('key must be a string; received %r' % key)
+    if not isinstance(seconds, (int, long)):
+      raise TypeError('seconds must be a number; received %r' % seconds)
+    if namespace is None:
+      namespace = namespace_manager.get_namespace()
+    return self.memcache_del_batcher.add(key, (seconds, namespace, deadline))
+
+  def memcache_incr(self, key, delta=1, initial_value=None, namespace=None,
+                    deadline=None):
+    if not isinstance(key, basestring):
+      raise TypeError('key must be a string; received %r' % key)
+    if not isinstance(delta, (int, long)):
+      raise TypeError('delta must be a number; received %r' % delta)
+    if initial_value is not None and not isinstance(initial_value, (int, long)):
+      raise TypeError('initial_value must be a number or None; received %r' %
+                      initial_value)
+    if namespace is None:
+      namespace = namespace_manager.get_namespace()
+    return self.memcache_off_batcher.add((key, delta),
+                                          (initial_value, namespace, deadline))
+
+  def memcache_decr(self, key, delta=1, initial_value=None, namespace=None,
+                    deadline=None):
+    if not isinstance(key, basestring):
+      raise TypeError('key must be a string; received %r' % key)
+    if not isinstance(delta, (int, long)):
+      raise TypeError('delta must be a number; received %r' % delta)
+    if initial_value is not None and not isinstance(initial_value, (int, long)):
+      raise TypeError('initial_value must be a number or None; received %r' %
+                      initial_value)
+    if namespace is None:
+      namespace = namespace_manager.get_namespace()
+    return self.memcache_off_batcher.add((key, -delta),
+                                          (initial_value, namespace, deadline))

--- a/ndb/memcache_client.py
+++ b/ndb/memcache_client.py
@@ -19,10 +19,6 @@ from . import autobatcher
 from . import tasklets
 
 class MemcacheClient(object):
-  # NOTE: The default memcache prefix is altered if an incompatible change is
-  # required. Remember to check release notes when using a custom prefix.
-  _memcache_prefix = 'NDB9:'  # TODO: Might make this configurable
-
   def __init__(self, conn=None, auto_batcher_class=autobatcher.AutoBatcher, max_memcache=None):
     # NOTE: If conn is not None, config is only used to get the
     # auto-batcher limits.

--- a/ndb/model_test.py
+++ b/ndb/model_test.py
@@ -4080,7 +4080,7 @@ property <
     ctx.set_memcache_policy(True)
     ctx.set_memcache_timeout_policy(0)
     # Mock memcache.cas_multi_async().
-    save_memcache_cas_multi_async = ctx._memcache.cas_multi_async
+    save_memcache_cas_multi_async = ctx.memcache_client._memcache.cas_multi_async
     memcache_args_log = []
 
     def mock_memcache_cas_multi_async(*args, **kwds):
@@ -4104,7 +4104,7 @@ property <
     e5 = MyModel(name='5')
     # Test that the timeouts make it through to memcache and Cloud Datastore.
     try:
-      ctx._memcache.cas_multi_async = mock_memcache_cas_multi_async
+      ctx.memcache_client._memcache.cas_multi_async = mock_memcache_cas_multi_async
       ctx._conn.async_put = mock_conn_async_put
       [f1, f3] = model.put_multi_async([e1, e3],
                                        memcache_timeout=7,
@@ -4123,7 +4123,7 @@ property <
       eventloop.run()  # Wait for async memcache request to complete.
       # (And there are straggler events too, but they don't matter here.)
     finally:
-      ctx._memcache.cas_multi_async = save_memcache_cas_multi_async
+      ctx.memcache_client._memcache.cas_multi_async = save_memcache_cas_multi_async
       ctx._conn.async_put = save_conn_async_put
     self.assertEqual([e1.key, e2.key, e3.key, e4.key, e5.key],
                      [x1, x2, x3, x4, x5])

--- a/ndb/test_utils.py
+++ b/ndb/test_utils.py
@@ -34,6 +34,7 @@ from .google_test_imports import datastore_stub_util
 from .google_test_imports import testbed
 from .google_test_imports import unittest
 
+from . import autobatcher
 from . import context
 from . import model
 from . import tasklets
@@ -96,7 +97,7 @@ class NDBBaseTest(unittest.TestCase):
   def ResetKindMap(self):
     model.Model._reset_kind_map()
 
-  def MakeContext(self, config=None, auto_batcher_class=context.AutoBatcher,
+  def MakeContext(self, config=None, auto_batcher_class=autobatcher.AutoBatcher,
                   default_model=None, conn=None):
     if not conn:
       conn = self.MakeConnection(config=config,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+googleapis-common-protos==1.5.2
+googledatastore==7.0.1
+httplib2==0.9.2
+oauth2client==3.0.0
+proto-google-cloud-datastore-v1==0.90.4
+protobuf==3.4.0
+pyasn1==0.3.3
+pyasn1-modules==0.1.1
+rsa==3.4.2
+six==1.10.0


### PR DESCRIPTION
This change:
- makes ndb's requirements more explicit through the use of the pip standard `requirements.txt`
- extracts `AutoBatcher` from `context.py` into `autobatcher.py`
- extracts memcache-related functionality from `Context` into `MemcacheClient` in `memcache_client.py`, while preserving `Context`'s memcache API