### PR TITLE
Add support for datetime.time and datetime.date to GenericProperty

### DIFF
--- a/ndb/model_test.py
+++ b/ndb/model_test.py
@@ -3460,7 +3460,7 @@ property <
     class Goo(model.Model):
       prop = model.GenericProperty()
 
-    g = Goo(prop=datetime.time(12))
+    g = Goo(prop=datetime.timedelta(seconds=12))
     self.assertRaises(NotImplementedError, g.put)
 
   def testGenericPropertyCompressedRefusesIndexed(self):


### PR DESCRIPTION
Expando explodes if you try to set values that were read from DateProperty or TimeProperty. 
This change adds support for datetime.date and datetime.time so we no longer hit: Property X does not support <type 'datetime.date'> types